### PR TITLE
built screen,showtime,booking schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,22 +4,22 @@ const cors = require('cors');
 const cookieParser = require('cookie-parser');
 const movieRoutes = require('./routes/movieRoutes');
 const theatersRoute = require("./routes/theaters");
-const adminTheaterRoutes = require("./routes/adminTheaterRoutes");
+const adminTheaterRoutes = require("./routes/adminTheater");
 
 require('dotenv').config();
 
-const authRouter = require('./routes/authRoutes');
+const authRoutes = require('./routes/authRoutes');
 const connectDB = require('./config/database');
 
 const app = express();
 app.use(cors({
-    origin: 'http://localhost:3000', 
+    origin: 'http://localhost:3000',
     credentials: true
 }));
 app.use(express.json());
 app.use(cookieParser()); // required to read cookies   
 
-app.use('/', authRouter);
+app.use('/', authRoutes);
 app.use('/movies', movieRoutes);
 app.use("/theaters", theatersRoute);
 app.use("/admin/theaters", adminTheaterRoutes);

--- a/models/Booking.js
+++ b/models/Booking.js
@@ -1,0 +1,37 @@
+const mongoose = require("mongoose");
+
+const bookedSeatSchema = new mongoose.Schema({
+    row: { type: String, required: true },
+    number: { type: Number, required: true },
+    seatType: { type: String, required: true },
+    price: { type: Number, required: true },
+});
+
+const bookingSchema = new mongoose.Schema({
+    user: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "User",
+        required: true,
+    },
+    showtime: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "Showtime",
+        required: true,
+    },
+    seats: [bookedSeatSchema],
+    totalAmount: {
+        type: Number,
+        required: true,
+    },
+    status: {
+        type: String,
+        enum: ["booked", "cancelled"],
+        default: "booked",
+    },
+    bookedAt: {
+        type: Date,
+        default: Date.now,
+    },
+}, { timestamps: true });
+
+module.exports = mongoose.model("Booking", bookingSchema);

--- a/models/Movie.js
+++ b/models/Movie.js
@@ -7,6 +7,8 @@ const movieSchema = new mongoose.Schema({
   overview: String,
   poster_path: String,
   release_date: String,
+  runtime: Number,
+  language: String,
   genres: [String], // or TMDB genre IDs
   createdAt: { type: Date, default: Date.now },
 });

--- a/models/Screen.js
+++ b/models/Screen.js
@@ -1,0 +1,31 @@
+const mongoose = require("mongoose");
+
+const seatSchema = new mongoose.Schema({
+    row: { type: String, required: true },
+    number: { type: Number, required: true },
+    seatType: { type: String, default: "regular" }, // e.g., 'VIP', 'premium'
+    price: { type: Number, required: true },
+});
+
+const screenSchema = new mongoose.Schema({
+    theater: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "Theater",
+        required: true,
+    },
+    screenName: {
+        type: String,
+        required: true,
+    },
+    totalRows: {
+        type: Number,
+        required: true,
+    },
+    seatsPerRow: {
+        type: Number,
+        required: true,
+    },
+    seats: [seatSchema],
+});
+
+module.exports = mongoose.model("Screen", screenSchema);

--- a/models/Showtime.js
+++ b/models/Showtime.js
@@ -1,0 +1,39 @@
+const mongoose = require("mongoose");
+
+const showtimeSchema = new mongoose.Schema({
+    movie: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "Movie",
+        required: true,
+    },
+    screen: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "Screen",
+        required: true,
+    },
+    theater: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "Theater",
+        required: true,
+    },
+    startTime: {
+        type: Date,
+        required: true,
+    },
+    language: {
+        type: String,
+        default: "Hindi",
+    },
+    format: {
+        type: String,
+        enum: ["2D", "3D", "IMAX"],
+        default: "2D",
+    },
+    priceOverride: {
+        type: Map,
+        of: Number,
+        default: undefined, // Optional override per seat type: { vip: 400, premium: 300 }
+    },
+}, { timestamps: true });
+
+module.exports = mongoose.model("Showtime", showtimeSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "validator": "^13.15.15"
       }
     },
-    "node_modules/@types/webidl-conversions": {},
     "node_modules/accepts": {
       "version": "2.0.0",
       "license": "MIT",
@@ -46,6 +45,8 @@
     },
     "node_modules/axios": {
       "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/routes/adminTheater.js
+++ b/routes/adminTheater.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const Theater = require("../models/Theater");
-const { requireAuth, requireRole } = require("../middleware/auth");
+const { requireAuth, requireRole } = require("../middlewares/auth");
 
 const router = express.Router();
 

--- a/services/seedScreens.js
+++ b/services/seedScreens.js
@@ -1,0 +1,84 @@
+const mongoose = require("mongoose");
+const dotenv = require("dotenv");
+const Theater = require("../models/Theater");
+const Screen = require("../models/Screen");
+
+dotenv.config();
+
+function generateSeatLayout(totalRows = 5, seatsPerRow = 10) {
+    const seats = [];
+    for (let r = 0; r < totalRows; r++) {
+        const row = String.fromCharCode(65 + r); // A, B, C...
+        const price = getPriceForRow(row);
+        for (let n = 1; n <= seatsPerRow; n++) {
+            seats.push({
+                row,
+                number: n,
+                seatType: getSeatType(row),
+                price,
+            });
+        }
+    }
+    return seats;
+}
+
+function getPriceForRow(row) {
+    if (["A", "B"].includes(row)) return 300; // Front rows (VIP)
+    if (["C", "D"].includes(row)) return 250; // Middle rows (Premium)
+    return 200; // Back rows (Regular)
+}
+
+function getSeatType(row) {
+    if (["A", "B"].includes(row)) return "vip";
+    if (["C", "D"].includes(row)) return "premium";
+    return "regular";
+}
+
+mongoose
+    .connect(process.env.MONGO_URI, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+    })
+    .then(async () => {
+        console.log("✅ Connected to MongoDB");
+
+        const theaters = await Theater.find();
+        console.log(`📍 Found ${theaters.length} theaters in DB`);
+
+        let totalScreensInserted = 0;
+
+        for (const theater of theaters) {
+            const existingScreens = await Screen.find({ theater: theater._id });
+            if (existingScreens.length > 0) {
+                console.log(`⏭️ Skipping ${theater.name} (screens already exist)`);
+                continue;
+            }
+
+            const screenCount = theater.screens || 1;
+
+            for (let i = 1; i <= screenCount; i++) {
+                const totalRows = 6;
+                const seatsPerRow = 10;
+
+                const screen = new Screen({
+                    theater: theater._id,
+                    screenName: `Screen ${i}`,
+                    totalRows,
+                    seatsPerRow,
+                    seats: generateSeatLayout(totalRows, seatsPerRow),
+                });
+
+                await screen.save();
+                totalScreensInserted++;
+            }
+
+            console.log(`✅ Added ${screenCount} screens for ${theater.name}`);
+        }
+
+        console.log(`🎉 Done! ${totalScreensInserted} screens seeded`);
+        process.exit(0);
+    })
+    .catch((err) => {
+        console.error("❌ Seeding error:", err);
+        process.exit(1);
+    });

--- a/services/seedShowtime.js
+++ b/services/seedShowtime.js
@@ -1,0 +1,64 @@
+const mongoose = require("mongoose");
+const dotenv = require("dotenv");
+const Movie = require("../models/Movie");
+const Theater = require("../models/Theater");
+const Screen = require("../models/Screen");
+const Showtime = require("../models/Showtime");
+
+dotenv.config();
+
+const showTimes = [10, 14, 18, 21]; // Hours: 10AM, 2PM, 6PM, 9PM
+
+async function seedShowtimes() {
+    await mongoose.connect(process.env.MONGO_URI, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+    });
+
+    console.log("✅ Connected to MongoDB");
+
+    // Clear old showtimes
+    await Showtime.deleteMany({});
+    console.log("🧹 Cleared existing showtimes");
+
+    const movies = await Movie.find({});
+    if (movies.length === 0) {
+        console.error("❌ No movies found in DB");
+        process.exit(1);
+    }
+
+    const screens = await Screen.find({}).populate("theater");
+
+    let count = 0;
+
+    for (const screen of screens) {
+        for (let dayOffset = 0; dayOffset < 7; dayOffset++) {
+            for (const hour of showTimes) {
+                const date = new Date();
+                date.setHours(hour, 0, 0, 0);
+                date.setDate(date.getDate() + dayOffset);
+
+                const movie = movies[Math.floor(Math.random() * movies.length)];
+
+                const showtime = new Showtime({
+                    movie: movie._id,
+                    screen: screen._id,
+                    theater: screen.theater._id,
+                    startTime: date,
+                    language: "Hindi",
+                    format: "2D",
+                });
+
+                await showtime.save();
+                count++;
+            }
+        }
+    }
+
+    console.log(`Seeded ${count} showtimes`);
+    process.exit(0);
+}
+seedShowtimes().catch((err) => {
+    console.error("❌ Error seeding showtimes:", err);
+    process.exit(1);
+});


### PR DESCRIPTION
This PR introduces:

🖥️ Screen model linked to theaters
🪑 Auto-generated seat layouts (with price, type, booking status)
⏰ Showtimes per screen (10AM, 2PM, 6PM for 7 days)
🎞️ Each showtime links to a Movie
🎟️ Basic Booking model (user, showtime, selected seats)

Includes:
Seed scripts for screens & showtimes
Idempotent logic: avoids duplicate entries

Prepares backend for:
Seat selection
Movie schedules
Booking flow